### PR TITLE
Mark flaky tests using pytest-rerunfailures

### DIFF
--- a/transport_data/tests/test_estat.py
+++ b/transport_data/tests/test_estat.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from transport_data.estat import get, list_flows
@@ -7,6 +9,7 @@ def test_list_flows():
     list_flows()
 
 
+@pytest.mark.flaky(condition="GITHUB_ACTIONS" in os.environ, reruns=5)
 @pytest.mark.parametrize("df_id", list_flows())
 def test_get(df_id):
     get(df_id)


### PR DESCRIPTION
Some network tests, e.g. for accessing Eurostat, fail sporadically on GitHub Actions. Use [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures) so that these are re-run automatically; they will usually pass on a subsequent attempt.