### PR TITLE
Release v24.2.5

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -69,12 +69,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with: { python-version: 3.x }
+    - run: python -m pip install pre-commit && python -m pip freeze --local
+    - uses: actions/cache@v4
       with:
-        python-version: 3.x
-
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Force recreation of pre-commit virtual environment for mypy
       if: github.event_name == 'schedule'  # Comment this line to run on a PR
-      run: gh cache list -L 999 | cut -f2 | grep pre-commit | xargs -I{} gh cache delete "{}" || true
-      env: { GH_TOKEN: "${{ github.token }}" }
-
-    - uses: pre-commit/action@v3.0.0
+      run: pre-commit clean
+    - run: pre-commit run --all-files --color=always --show-diff-on-failure

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,11 +7,12 @@ What's new
 v24.2.5
 =======
 
+- Add :mod:`.oica` (:doc:`oica`) module (:pull:`13`).
 - Improve :mod:`.store` to handle both local and registry storage; expand :doc:`documentation <store>` (:pull:`11`).
 - Add :func:`.iamc.variable_cl_for_dsd`; expand documentation of :doc:`IAM data <iamc>` (:pull:`10`).
 - :mod:`transport_data` supports and is tested on Python 3.8 through 3.12 (:pull:`8`).
 
-23.5.11
-=======
+v23.5.11
+========
 
 Initial release

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-Next release
-============
+.. Next release
+.. ============
+
+v24.2.5
+=======
 
 - Improve :mod:`.store` to handle both local and registry storage; expand :doc:`documentation <store>` (:pull:`11`).
 - Add :func:`.iamc.variable_cl_for_dsd`; expand documentation of :doc:`IAM data <iamc>` (:pull:`10`).


### PR DESCRIPTION
- Mark v24.2.5 in doc/whatsnew
- Add #13 to doc/whatsnew
- Inline pre-commit action steps, since the original is no longer maintained (cf. pre-commit/action#189, pre-commit/action#188)
