### PR TITLE
Use `dsss.store` for SDMX artefact storage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+**Required:** write a single sentence that describes the changes made by this pull request.
+
+### PR checklist
+<!--
+Do not delete any of the following items. If one is not required,
+strike it out and leave a note explaining why. For example:
+
+- ~Update documentation~ N/A; bug fix
+-->
+- [ ] Checks all ✅
+- [ ] Update documentation
+- [ ] Update doc/whatsnew.rst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
   - id: mypy
     additional_dependencies:
     - click
+    - dsss
     - lxml-stubs
     - pandas-stubs
     - platformdirs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,6 +82,7 @@ extlinks = {
 intersphinx_mapping = {
     "click": ("https://click.palletsprojects.com/en/8.1.x/", None),
     "docutils": ("https://sphinx-docutils.readthedocs.io/en/latest", None),
+    "dsss": ("https://dsss.readthedocs.io/en/stable", None),
     "jinja2": ("https://jinja.palletsprojects.com/en/3.1.x", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "platformdirs": ("https://platformdirs.readthedocs.io/en/latest/", None),

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,13 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Use :mod:`dsss.store` classes for SDMX artefact storage (:pull:`27`).
+
+  - :class:`transport_data.store.UnionStore` is now a lightweight subclass of :class:`dsss.store.UnionStore`.
+  - Add :attr:`.Config.registry_remote_url`.
 
 v24.10.8
 ========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ requires-python = ">=3.9"
 dependencies = [
   "click",
   "docutils",
+  "dsss[git-store] >= 1.3.0",
   "Jinja2",
   "openpyxl",
   "packaging",

--- a/transport_data/adb/__init__.py
+++ b/transport_data/adb/__init__.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import sdmx.model.v21 as m
 
-from transport_data import STORE as registry
+from transport_data import STORE
 from transport_data.util.pluggy import hookimpl
 from transport_data.util.pooch import Pooch
 from transport_data.util.sdmx import anno_generated
@@ -315,10 +315,10 @@ def convert(part):
         ds = convert_sheet(df, annos)
 
         # Write the DSD and DFD
-        registry.write(ds.described_by)
-        registry.write(ds.structured_by)
+        STORE.set(ds.described_by)
+        STORE.set(ds.structured_by)
         # Write the data itself, to SDMX-ML and CSV
-        registry.write(ds)
+        STORE.set(ds)
 
     # Write the lists of "Economy" codes and measures/concepts accumulated while
     # converting
@@ -326,4 +326,4 @@ def convert(part):
     for obj in (CL_ECONOMY, CS_MEASURE):
         obj.maintainer = a
         obj.version = "0.1.0"
-        registry.write(obj)
+        STORE.set(obj)

--- a/transport_data/adb/__init__.py
+++ b/transport_data/adb/__init__.py
@@ -152,13 +152,15 @@ def read_sheet(
     # Convert metadata rows to a collection of temporary annotations
     aa = m.AnnotableArtefact()
     for _, data in meta_df.iterrows():
-        title = data[0].rstrip(":")
+        title = data.iloc[0].rstrip(":")
         anno_id = title.upper().replace(" ", "-")
         aa.annotations.append(
             m.Annotation(
                 id=anno_id,
                 title=title,
-                text=data[1] if isinstance(data[1], str) else repr(data[1]),
+                text=data.iloc[1]
+                if isinstance(data.iloc[1], str)
+                else repr(data.iloc[1]),
             )
         )
 

--- a/transport_data/config.py
+++ b/transport_data/config.py
@@ -19,6 +19,12 @@ class Config:
         default_factory=lambda: user_data_path("transport-data", ensure_exists=True)
     )
 
+    #: Git remote URL for the TDC SDMX registry.
+    #:
+    #: Users with SSH keys registered on github.com may wish to use instead
+    #: ``git@github.com:transport-data/registry.git``.
+    registry_remote_url: str = "https://github.com/transport-data/registry.git"
+
     #: Mapping from maintainer IDs to either "local" (stored in a :class:`.LocalStore`)
     #: or "registry" (stored in the :class:`.Registry`).
     store_map: dict = field(

--- a/transport_data/estat/__init__.py
+++ b/transport_data/estat/__init__.py
@@ -12,7 +12,7 @@ provider-specific conversion code is needed.
 import click
 import sdmx
 
-from transport_data import STORE as registry
+from transport_data import STORE
 
 # General functions
 
@@ -31,7 +31,7 @@ def get(dataflow_id: str):
     sm = client.dataflow(dataflow_id)
 
     # Write each of the structure objects received to a separate file
-    registry.write(sm, annotate=False)
+    STORE.update_from(sm)
 
     # Retrieve the data itself
     dm = client.data(dataflow_id)
@@ -44,7 +44,7 @@ def get(dataflow_id: str):
     ds.structured_by = ds.described_by.structure
 
     # Write to file
-    path = registry.write(ds)
+    path = STORE.set(ds)
     print(f"Retrieved {path}")
     print("          and associated structures")
 

--- a/transport_data/ipcc/structure.py
+++ b/transport_data/ipcc/structure.py
@@ -268,10 +268,10 @@ def gen_structures() -> None:
 
     ma_args = dict(
         maintainer=org.get_agencies()[0],
-        version="0.1",
+        version="0.1.0",
         is_final=True,
         is_external_reference=False,
     )
 
-    STORE.setdefault(gen_cl_T311(**ma_args))
-    STORE.setdefault(gen_cs_ch3(**ma_args))
+    STORE.set(gen_cl_T311(**ma_args))
+    STORE.set(gen_cs_ch3(**ma_args))

--- a/transport_data/jrc/__init__.py
+++ b/transport_data/jrc/__init__.py
@@ -23,7 +23,7 @@ import numpy as np
 import pandas as pd
 import sdmx.model.v21 as m
 
-from transport_data import STORE as registry
+from transport_data import STORE
 from transport_data.util.pluggy import hookimpl
 from transport_data.util.pooch import Pooch
 from transport_data.util.sdmx import anno_generated
@@ -447,14 +447,14 @@ def convert(geo):
                     id="tdc-comment", text=f"Primary measure is {measure_concept!r}"
                 )
             )
-            registry.write(obj)
+            STORE.set(obj)
 
     # Write code lists, measure concept scheme to file
     a = get_agencies()[0]
     for obj in chain(CL.values(), [CS_MEASURE]):
         obj.maintainer = a
         obj.version = "0.1.0"
-        registry.write(obj)
+        STORE.set(obj)
 
     raise NotImplementedError("Merging data for multiple GEO")
 

--- a/transport_data/oica/__init__.py
+++ b/transport_data/oica/__init__.py
@@ -170,7 +170,7 @@ def convert_single_file(
         cl_geo, df["GEO"], maintainer=get_agencies()[0], version="0.1"
     )
     # Store `cl_geo`
-    STORE.write(cl_geo)
+    STORE.set(cl_geo)
 
     # Transform data
     # - Replace GEO values with codes from `cl_geo`.
@@ -355,7 +355,8 @@ def get_cl_geo() -> "sdmx.model.common.Codelist":
         version="0.1",
     )
 
-    return STORE.setdefault(candidate)
+    STORE.set(candidate)
+    return candidate
 
 
 @lru_cache
@@ -401,7 +402,7 @@ def get_conceptscheme() -> "sdmx.model.common.ConceptScheme":
     for id_ in ("OBS_VALUE",):
         cs.append(common.Concept(id=id_))
 
-    STORE.write(cs)
+    STORE.set(cs)
 
     return cs
 
@@ -431,8 +432,10 @@ def get_structures(
         is_external_reference=False,
     )
 
-    dfd = STORE.setdefault(v21.DataflowDefinition(id=f"DF_{base}", **ma_args))
-    dsd = STORE.setdefault(v21.DataStructureDefinition(id=f"DS_{base}", **ma_args))
+    dfd = v21.DataflowDefinition(id=f"DF_{base}", **ma_args)
+    STORE.set(dfd)
+    dsd = v21.DataStructureDefinition(id=f"DS_{base}", **ma_args)
+    STORE.set(dsd)
 
     if not dfd.is_final:
         # Associate
@@ -440,7 +443,7 @@ def get_structures(
 
         # Mark as complete
         dfd.is_final = True
-        STORE.write(dfd)
+        STORE.set(dfd)
 
     if not dsd.is_final:
         cs = get_conceptscheme()
@@ -464,7 +467,7 @@ def get_structures(
 
         # Mark as complete
         dsd.is_final = True
-        STORE.write(dsd)
+        STORE.set(dsd)
 
     return dfd, dsd
 

--- a/transport_data/org/__init__.py
+++ b/transport_data/org/__init__.py
@@ -73,7 +73,7 @@ def get_agencyscheme(version: Union[None, str] = None) -> "sdmx.model.v21.Agency
 
     as_.version = version
     if as_.version is None:
-        registry.assign_version(as_)
+        registry.assign_version(as_, patch=1)
 
     return as_
 
@@ -83,4 +83,4 @@ def refresh():
     from transport_data import STORE
 
     as_ = get_agencyscheme()
-    STORE.write(as_)
+    STORE.set(as_)

--- a/transport_data/org/cli.py
+++ b/transport_data/org/cli.py
@@ -29,7 +29,7 @@ def refresh(version):
 
     from . import get_agencyscheme
 
-    STORE.write(get_agencyscheme(version=version))
+    STORE.set(get_agencyscheme(version=version))
 
 
 @main.command("read")

--- a/transport_data/org/metadata/__init__.py
+++ b/transport_data/org/metadata/__init__.py
@@ -191,7 +191,7 @@ def get_msd() -> "v21.MetadataStructureDefinition":
         rs.getdefault(id_, concept_identity=ci)
 
     # NB Currently not supported by sdmx1; results in an empty XML collection
-    STORE.write(msd)
+    STORE.set(msd)
 
     return msd
 

--- a/transport_data/store.py
+++ b/transport_data/store.py
@@ -34,7 +34,7 @@ class UnionStore(dsss.store.UnionStore):
 
     def __init__(self, config: "transport_data.config.Config") -> None:
         super().__init__(
-            hook={"pre-write": anno_generated},
+            hook={"before set": anno_generated},
             store=dict(
                 local=dsss.store.FlatFileStore(path=config.data_path.joinpath("local")),
                 registry=dsss.store.GitStore(

--- a/transport_data/store.py
+++ b/transport_data/store.py
@@ -1,19 +1,17 @@
-"""Local data storage."""
+"""Local data storage.
+
+.. todo:: Add the following to base capabilities of :class:`.UnionStore`::
+
+   - :py:`write(..., annotate=True)`
+"""
 
 import logging
-import re
-import subprocess
-from abc import ABC, abstractmethod
-from functools import singledispatchmethod
-from pathlib import Path
-from typing import TYPE_CHECKING, List, Literal, Mapping, Set, Tuple, Union
+from typing import TYPE_CHECKING
 
 import click
-import packaging.version
-import sdmx
+import dsss.store
 import sdmx.model.v21 as m
 import sdmx.urn
-from sdmx.message import StructureMessage
 
 from transport_data.util.sdmx import anno_generated
 
@@ -23,334 +21,77 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def _full_urn(value: str) -> str:
-    """Convert possibly partial `value` to a complete SDMX URN."""
-    urn_base = "urn:sdmx:org.sdmx.infomodel."
-    if value.startswith(urn_base):
-        return value
-    else:
-        return f"{urn_base}package.{value}"
+class UnionStore(dsss.store.UnionStore):
+    """A store that maps between a :class:`.LocalStore` and :class:`.Registry`.
 
+    This class extends :class:`dsss.store.UnionStore` with the following behaviour:
 
-_SHORT_URN_EXPR = re.compile(r"(urn:sdmx:org\.sdmx\.infomodel\.[^\.]+\.)?(?P<short>.*)")
-
-
-def _short_urn(value: str) -> str:
-    m = _SHORT_URN_EXPR.match(value)
-    assert m
-    return m.group("short")
-
-
-def _maintainer(obj: Union[m.MaintainableArtefact, m.DataSet]) -> m.Agency:
-    """Return a maintainer for `obj`.
-
-    If `obj` is :class:`.DataSet`, the maintainer of the data flow is used.
+    - The sub-stores are initialized from an instance of :class:`.Config`.
+    - :meth:`assign_version` and :meth:`get` have extended behaviour. See the
+      documentation of each method.
+    - Additional methods :meth:`clone` and :meth:`add_to_registry`.
     """
-    if isinstance(obj, m.MaintainableArtefact):
-        return obj.maintainer
-    else:
-        assert obj.described_by
-        return obj.described_by.maintainer
 
+    def __init__(self, config: "transport_data.config.Config") -> None:
+        super().__init__(
+            hook={"pre-write": anno_generated},
+            store=dict(
+                local=dsss.store.FlatFileStore(path=config.data_path.joinpath("local")),
+                registry=dsss.store.GitStore(
+                    path=config.data_path.joinpath("registry"),
+                    remote_url=config.registry_remote_url,
+                ),
+            ),
+        )
 
-class BaseStore(ABC):
-    """A class for file-based storage of SDMX artefacts."""
+    # Overrides of methods of dsss.store.UnionStore or its parents
 
-    #: Top level file system path containing stored files.
-    path: Path
+    def assign_version(self, obj, **kwargs) -> None:
+        """Assign a version to `obj` subsequent to any existing versions.
 
-    @abstractmethod
-    def __init__(self, config: "transport_data.config.Config") -> None: ...
+        Compared to the parent class, this implementation ensures that the assigned
+        version is :class:`str`. This is needed because :mod:`sdmx` currently fails to
+        write :class:`.Version` to SDMX-ML.
 
-    def get(self, urn: str) -> object:
-        """Retrieve an object given its full or partial `urn`."""
-        # Identify the path to the object
-        urn = _full_urn(urn)
-        path = self.path_for(urn)
-        assert path.exists(), f"No object {path}"
+        .. todo:: Remove this override once the issue is fixed in :mod:`sdmx`.
+        """
+        super().assign_version(obj, **kwargs)
+        obj.version = str(obj.version)
 
-        # Read an SDMX Message from the path
-        msg = sdmx.read_sdmx(path)
+    def get(self, key: str):
+        """Return an object given its `key`.
 
-        # Extract the object
-        m = sdmx.urn.match(urn)
-        result = msg.get(m["id"])
-        assert result
+        Compared to the parent class, this implementation:
 
-        return result
-
-    def list(self, maintainer_id: str) -> List[str]:
-        """Return a list of URNs for objects with `maintainer_id`."""
-        base = self.path.joinpath(maintainer_id)
-        result: Set[str] = set()
-        for path in sorted(base.glob("*.xml")):
-            msg = sdmx.read_sdmx(path)
-            for _, cls in msg.iter_collections():
-                result.update(_short_urn(obj.urn) for obj in msg.objects(cls).values())
-
-        return sorted(result)
-
-    @singledispatchmethod
-    def path_for(self, obj: m.MaintainableArtefact) -> Path:
-        """Determine a path and filename for `obj`."""
-        return self.path.joinpath(
-            obj.maintainer.id, f"{obj.__class__.__name__}_{obj.maintainer.id}_{obj.id}"
-        ).with_suffix(".xml")
-
-    @path_for.register
-    def _(self, obj: m.DataSet) -> Path:
-        """Determine a path and filename for `obj`."""
-        # Generate a path for the data set's corresponding data flow
-        tmp = self.path_for(obj.described_by)
-        return tmp.with_name(tmp.name.replace("DataflowDefinition", "DataSet"))
-
-    @path_for.register
-    def _(self, urn: str) -> Path:
-        """Generate a Path given a `urn`."""
-        m = sdmx.urn.match(_full_urn(urn))
-        return self.path.joinpath(
-            m["agency"], "_".join([m["class"], m["agency"], m["id"]])
-        ).with_suffix(".xml")
-
-    def setdefault(self, default: m.MaintainableArtefact) -> m.MaintainableArtefact:
-        """If an object with the URN of `default` is in the registry, return it.
-
-        Otherwise, :meth:`.write` `default`.
+        - Expands `key` from a partial URN (e.g. "AgencyScheme=TDCI:TDCI(1.0.0)") to a
+          full URN.
+        - Handles `key` that is a partial URN without a specific version, e.g.
+          "AgencyScheme=TDCI:TDCI". In this case, the greatest version of the referenced
+          artefact is returned.
         """
         try:
-            # Existing object
-            return self.get(sdmx.urn.make(default))
-        except AssertionError:
-            self.write(default)
-            return default
+            full_urn = sdmx.urn.expand(key)
+            return super().get(full_urn)
+        except KeyError:
+            match = sdmx.urn.match(full_urn)
+            if match and match["version"] is None:
+                if versions := self.list_versions(
+                    m.get_class(match["class"]), match["agency"], match["id"]
+                ):
+                    return super().get(full_urn.replace("(None)", f"({versions[-1]})"))
+            raise
 
-    @singledispatchmethod
-    def write(
-        self,
-        obj: Union[m.MaintainableArtefact, m.DataSet],
-        *,
-        annotate: bool = True,
-        **kwargs,
-    ) -> Path:
-        """Write `obj` into the registry as SDMX-ML.
+    # Additional methods for this class
 
-        The path and filename are determined by the object properties.
-        """
-        if len(kwargs):
-            raise TypeError(f"Extra keyword arguments: {kwargs}")
-
-        path = self.path_for(obj)
-
-        # Make the parent directory (but not multiple parents)
-        path.parent.mkdir(exist_ok=True)
-
-        if isinstance(obj, m.AnnotableArtefact) and annotate:
-            # Annotate the object with information about how it was generated
-            # TODO don't do this for files retrieved directly from an SDMX API
-            anno_generated(obj)
-
-        if isinstance(obj, m.MaintainableArtefact):
-            # Encapsulate in a StructureMessage
-            sm = sdmx.message.StructureMessage()
-            sm.add(obj)
-            msg: sdmx.message.Message = sm
-        else:
-            dm = sdmx.message.DataMessage()
-            dm.data.append(obj)
-            msg = dm
-
-        with open(path, "wb") as f:
-            f.write(sdmx.to_xml(msg, pretty_print=True))
-
-        log.info(f"Wrote {path}")
-
-        if isinstance(obj, m.DataSet):
-            csv_path = path.with_suffix(".csv")
-            sdmx.to_csv(obj, path=csv_path, attributes="gso")
-            log.info(f"Wrote {csv_path}")
-
-        return path
-
-    @write.register
-    def _write_structuremessage(self, obj: StructureMessage, **kwargs):
-        # Write each of the structure objects a separate file
-        for kind in ("codelist", "concept_scheme", "dataflow", "structure"):
-            for obj_ in getattr(obj, kind).values():
-                self.write(obj_, **kwargs)
-
-    def assign_version(
-        self,
-        obj: m.MaintainableArtefact,
-        default="0.0.0",
-        increment: Union[bool, Tuple[bool, bool, bool]] = False,
-    ) -> None:
-        """Assign a version to `obj`.
-
-        If `increment` is :data:`False`, the version will be the latest already existing
-        in the registry, if any, or `default` if no version of `obj` is stored.
-
-        Otherwise, `increment` should be a 3-tuple of :class:`bool`, which are passed as
-        arguments to :func:`next_version`.
-        """
-        if increment is False:
-            obj.version = (self.list_versions(obj) or [default])[-1]
-        else:
-            if not isinstance(increment, tuple):
-                increment = (increment, False, False)
-            obj.version = self.next_version(obj, *increment)
-
-    def list_versions(self, obj: m.MaintainableArtefact) -> List[str]:
-        """List all versions of `obj` already stored in the registry."""
-
-        # Path that would result from writing `obj`
-        path = self.path_for(obj)
-
-        if not path.exists():
-            return []
-
-        # Read an SDMX Message from the path
-        msg = sdmx.read_sdmx(path)
-
-        # Iterate over objects
-        versions = set()
-        for _, cls in msg.iter_collections():
-            for obj in msg.objects(cls).values():
-                versions.add(obj.version)
-
-        return sorted(versions)
-
-    def next_version(
-        self, obj: m.MaintainableArtefact, major=False, minor=True, patch=False
-    ) -> str:
-        """Return an incremented version string for `obj`."""
-        v = packaging.version.parse(self.list_versions(obj)[-1])
-        return f"{v.major + int(major)}.{v.minor + int(minor)}.{v.micro + int(patch)}"
-
-
-class LocalStore(BaseStore):
-    """Unversioned local storage."""
-
-    def __init__(self, config) -> None:
-        self.path = config.data_path.joinpath("local")
-        self.path.mkdir(parents=True, exist_ok=True)
-
-
-class Registry(BaseStore):
-    """Registry of TDCI-maintained structure information.
-
-    Currently these are stored in, and available from, the
-    `transport-data/registry <https://github.com/transport-data/registry>`_ GitHub
-    repository. This class handles the interaction with a local clone of that
-    repository.
-
-    In the future, they will be maintained on a full SDMX REST web service, and this
-    class will handle retrieving from and publishing to that web service, with
-    appropriate caching etc.
-    """
-
-    def __init__(self, config) -> None:
-        self.path = config.data_path.joinpath("registry")
-        if not self.path.exists():
-            print(f"WARNING: TDC registry not existing in {self.path}")
-            print("To clone, run: tdc registry clone")
-
-    def _gh(self, *parts):
-        """Invoke `gh`, the GitHub CLI client."""
-        return subprocess.run(("gh",) + parts)
-
-    def _git(self, *parts):
-        """Invoke `git` in the :attr:`path` directory."""
-        return subprocess.run(("git", "-C", str(self.path)) + parts)
-
-    def clone(self):
-        """Clone the repository."""
-        self._gh("repo", "clone", "transport-data/registry", str(self.path))
-
-    @singledispatchmethod
-    def write(
-        self,
-        obj: Union[m.MaintainableArtefact, m.DataSet],
-        *,
-        annotate: bool = True,
-        **kwargs,
-    ) -> Path:
-        """Write `obj` into the registry as SDMX-ML."""
-        show_status = kwargs.pop("_show_status", False)
-        result = super().write(obj, annotate=annotate, **kwargs)
-
-        # Add to git, but do not commit
-        # NB if the path is specifically covered by a .gitignore entry, this will generate
-        #    some advice messages but have no effect. See e.g. registry/ESTAT/README.
-        # TODO ignore "The following paths are ignored by one of your .gitignore files"
-        self._git("add", str(result.relative_to(self.path)))
-        if show_status:
-            self._git("status")
-
-        return result
-
-    write.register(BaseStore._write_structuremessage)
-
-
-class UnionStore(BaseStore):
-    """A store that maps between a :class:`.LocalStore` and :class:`.Registry`."""
-
-    #: Instances of :class:`.LocalStore` and :class:`.Registry`.
-    store: Mapping[Literal["local", "registry"], BaseStore]
-
-    #: Mapping from maintainer IDs (such as "TEST" or "TDCI") to either "local" or
-    #: "registry".
-    map: Mapping[str, Literal["local", "registry"]]
-
-    def __init__(self, config) -> None:
-        self.store = dict(local=LocalStore(config), registry=Registry(config))
-        self.map = config.store_map
-
-    def _get_store(self, obj: m.MaintainableArtefact) -> BaseStore:
-        """Return the store that wants to handle `obj`."""
-        return self.store[self.map.get(_maintainer(obj).id, "local")]
-
-    def get(self, urn: str) -> object:
-        """Retrieve an object given its full or partial `urn`."""
-        # Identify the path to the object
-        urn = _full_urn(urn)
-        m = sdmx.urn.match(urn)
-
-        return self.store[self.map.get(m["agency"], "local")].get(urn)
-
-    def list(self, maintainer_id: str):
-        return sorted(
-            set(self.store["registry"].list(maintainer_id))
-            | set(self.store["local"].list(maintainer_id))
-        )
-
-    @singledispatchmethod
-    def write(
-        self,
-        obj: Union[m.MaintainableArtefact, m.DataSet],
-        *,
-        annotate: bool = True,
-        **kwargs,
-    ) -> Path:
-        """Write `obj` into the registry as SDMX-ML."""
-        return self._get_store(obj).write(obj, annotate=annotate, **kwargs)
-
-    write.register(BaseStore._write_structuremessage)
-
-    def assign_version(
-        self, obj: m.MaintainableArtefact, default="0.0.0", increment=False
-    ):
-        return self._get_store(obj).assign_version(
-            obj, default=default, increment=increment
-        )
+    def add_to_registry(self, urn: str):
+        """Copy data for `urn` from :class:`.LocalStore` to the :class:`.Registry`."""
+        full_urn = sdmx.urn.expand(urn)
+        obj = self.store["local"].get(full_urn)
+        self.store["registry"].set(obj)
 
     def clone(self):
         """Clone the underlying :class:`.Registry`."""
         self.store["registry"].clone()
-
-    def add_to_registry(self, urn: str):
-        """Copy data for `urn` from :class:`.LocalStore` to the :class:`.Registry`."""
-        obj = self.store["local"].get(urn)
-        self.store["registry"].write(obj)
 
 
 # Command-line interface
@@ -382,7 +123,7 @@ def list_cmd(context, maintainer_id):
     """List store contents for MAINTAINER."""
     from transport_data import STORE
 
-    for urn in STORE.list(maintainer_id):
+    for urn in STORE.list(maintainer=maintainer_id):
         print(urn)
 
 

--- a/transport_data/tests/test_store.py
+++ b/transport_data/tests/test_store.py
@@ -1,75 +1,80 @@
+from typing import TYPE_CHECKING
+
 import pytest
 import sdmx.model.v21
 import sdmx.model.v21 as m
 from click.testing import CliRunner
+from sdmx.model import common
 
 from transport_data.config import Config
 from transport_data.org import get_agencyscheme
-from transport_data.store import BaseStore, LocalStore, main
+from transport_data.store import main
+
+if TYPE_CHECKING:
+    import dsss.store
 
 
 class TestBaseStore:
+    """:mod:`dsss` classes provide features required by :mod:`transport_data`."""
+
     @pytest.fixture
-    def s(self, tmp_config: Config) -> BaseStore:
-        s = LocalStore(tmp_config)
-        s.write(get_agencyscheme())
+    def s(self, tmp_config: Config, sdmx_structures) -> "dsss.store.Store":
+        from dsss.store import DictStore
+
+        # Create a DictStore
+        s = DictStore()
+
+        # Set some items
+        s.set(sdmx_structures.codelist["FRUIT"])
+
         return s
 
-    @pytest.mark.parametrize(
-        "urn",
-        (
-            "AgencyScheme=TDCI:TDCI(0.1.0)",
-            "AgencyScheme=TDCI:TDCI",
-        ),
-    )
-    def test_get(self, sdmx_structures, s, urn) -> None:
-        """Objects can be retrieved by partial URN."""
-        result = s.get(urn)
-        assert isinstance(result, sdmx.model.v21.AgencyScheme)
+    def test_list_versions(self, s: "dsss.store.Store") -> None:
+        result = s.list_versions(common.Codelist, maintainer="TEST", id="FRUIT")
 
-    def test_list_versions(self, sdmx_structures, s: BaseStore) -> None:
-        cl = sdmx_structures.codelist["FRUIT"]
+        assert ("1.0.0",) == result
 
-        result = s.list_versions(cl)
+        assert tuple() == s.list_versions(common.Codelist, maintainer="TEST", id="FOO")
 
-        assert ["1.0.0"] == result
-
-        cl = m.Codelist(id="FOO", maintainer=m.Agency(id="TEST"))
-        assert [] == s.list_versions(cl)
-
-    @pytest.mark.parametrize(
-        "major, minor, patch, exp",
-        (
-            (False, True, False, "1.1.0"),  # Default
-        ),
-    )
-    def test_next_version(
-        self, sdmx_structures, s: BaseStore, major, minor, patch, exp
-    ) -> None:
-        cl = sdmx_structures.codelist["FRUIT"]
-
-        result = s.next_version(cl, major, minor, patch)
-
-        assert exp == result
-
-    def test_assign_version(self, sdmx_structures, s: BaseStore) -> None:
+    def test_assign_version(self, sdmx_structures, s: "dsss.store.Store") -> None:
         cl = m.Codelist(id="FRUIT", maintainer=m.Agency(id="TEST"))
 
-        s.assign_version(cl, increment=True)
+        s.assign_version(cl, major=1)
 
         assert "2.0.0" == cl.version
 
 
 class TestUnionStore:
-    def test_add_to_registry(self, tmp_store, sdmx_structures) -> None:
-        s = tmp_store
-        s.add_to_registry("Codelist=TEST:FRUIT(1.0.0)")
+    """Test the :class:`transport_data.store.UnionStore` subclass."""
 
-    def test_list(self, tmp_store, sdmx_structures) -> None:
-        result = tmp_store.list("TEST")
+    @pytest.fixture(scope="class")
+    def tdci_agencyscheme(self, tmp_store):
+        tmp_store.set(get_agencyscheme())
+
+    @pytest.mark.usefixtures("sdmx_structures")
+    def test_add_to_registry(self, tmp_store) -> None:
+        tmp_store.add_to_registry("Codelist=TEST:FRUIT(1.0.0)")
+
+    @pytest.mark.usefixtures("sdmx_structures", "tdci_agencyscheme")
+    @pytest.mark.parametrize(
+        "urn",
+        (
+            "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=TDCI:TDCI",
+            "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=TDCI:TDCI(0.0.1)",
+            "AgencyScheme=TDCI:TDCI(0.0.1)",
+            "AgencyScheme=TDCI:TDCI",
+        ),
+    )
+    def test_get(self, tmp_store, urn) -> None:
+        """Objects can be retrieved by partial URN."""
+        result = tmp_store.get(urn)
+        assert isinstance(result, sdmx.model.v21.AgencyScheme)
+
+    def test_list(self, tmp_store) -> None:
+        result = sorted(tmp_store.list(maintainer="TEST"))
         assert 5 == len(result)
-        assert "Codelist=TEST:COLOUR(1.0.0)" == result[0]
-        assert "DataStructureDefinition=TEST:PICKED(1.0.0)" == result[-1]
+        assert result[0].endswith("Codelist=TEST:COLOUR(1.0.0)")
+        assert result[-1].endswith("DataStructure=TEST:PICKED(1.0.0)"), result
 
 
 def test_cli_list(sdmx_structures):


### PR DESCRIPTION
This PR removes most of the code in `transport_data.store`, which was migrated to the `dsss` package in khaeru/dsss#9.

This achieves separation-of-concerns:

- `dsss` defines the basic Store interface and concrete classes.
- `transport_data` only uses these APIs, and defines a small subclass with additional behaviour that is particularly needed for TDC.