### PR TITLE
Add a CKAN client

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -43,11 +43,14 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: "**/pyproject.toml"
+
+    - uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
+        cache-dependency-glob: "**/pyproject.toml"
 
     - name: Install the Python package and dependencies
-      run: pip install --upgrade --upgrade-strategy=eager .[tests]
+      run: uv pip install --system --upgrade .[tests]
 
     - name: Clone the transport-data/registry repo
       run: coverage run -m transport_data store clone

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.2
+  rev: v1.13.0
   hooks:
   - id: mypy
     additional_dependencies:
@@ -20,7 +20,7 @@ repos:
     - types-tqdm
     args: []
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.9
+  rev: v0.8.1
   hooks:
   - id: ruff
   - id: ruff-format

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,11 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Add :mod:`.util.ckan`, including a :class:`~.ckan.Client` for access to CKAN instances (including the TDC instances); proxy classes for CKAN objects including :class:`~.ckan.Package`, :class:`~.ckan.Resource`, and mode (:pull:`35`).
+- Add :data:`.org.ckan.PROD` and :data:`.org.ckan.DEV` instances of :class:`.ckan.Client` (:pull:`35`).
 
 v24.11.25
 =========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 readme = "README.rst"
 requires-python = ">=3.9"
 dependencies = [
+  "ckanapi",
   "click",
   "docutils",
   "dsss[git-store] >= 1.3.0",
@@ -72,6 +73,7 @@ exclude = ["build/"]
 
 [[tool.mypy.overrides]]
 module = [
+  "ckanapi.*",
   "google_auth_oauthlib.*",
   "google.*",
   "googleapiclient.*",

--- a/transport_data/adb/__init__.py
+++ b/transport_data/adb/__init__.py
@@ -36,22 +36,49 @@ CS_MEASURE = m.ConceptScheme(
 #: Mapping from short codes for ATO data categories to file names.
 FILES = {
     # "ATO National Database Masterlist of Indicators",
-    "ACC": "ATO Workbook (ACCESS & CONNECTIVITY (ACC)).xlsx",
-    "APH": "ATO Workbook (AIR POLLUTION & HEALTH (APH)).xlsx",
-    "CLC": "ATO Workbook (CLIMATE CHANGE (CLC)).xlsx",
-    "INF": "ATO Workbook (INFRASTRUCTURE (INF)).xlsx",
-    "MIS": "ATO Workbook (MISCELLANEOUS (MIS)).xlsx",
-    "POL": "ATO Workbook (TRANSPORT POLICY (POL)).xlsx",
-    "RSA": "ATO Workbook (ROAD SAFETY (RSA)).xlsx",
-    "SEC": "ATO Workbook (SOCIO-ECONOMIC (SEC)).xlsx",
-    "TAS": "ATO Workbook (TRANSPORT ACTIVITY & SERVICES (TAS)).xlsx",
+    "ACC": (
+        "ATO Workbook (ACCESS & CONNECTIVITY (ACC)).xlsx",
+        "sha256:edd027a7f74bbdf82145f17acd6ecd8bd1fdd92d2e5e2be4bbcaaff09879e3de",
+    ),
+    "APH": (
+        "ATO Workbook (AIR POLLUTION & HEALTH (APH)).xlsx",
+        "sha256:548cfcf1f376dad747a3f1cebf7139767ba5bae5ee66aabd598f40a9e9890d20",
+    ),
+    "CLC": (
+        "ATO Workbook (CLIMATE CHANGE (CLC)).xlsx",
+        "sha256:aba2f02d684fe83c781378ae62ce4b1d548dd6737fe29768c86c620ed8efd65d",
+    ),
+    "INF": (
+        "ATO Workbook (INFRASTRUCTURE (INF)).xlsx",
+        "sha256:ea36a9303286b3d1ff5848b01402f8661d968771aa8b980db0aea73a00a9d0dd",
+    ),
+    "MIS": (
+        "ATO Workbook (MISCELLANEOUS (MIS)).xlsx",
+        "sha256:f17315b40434009966580bc3023c222d254b87a1b0c5eaf05a6a42c113b5393b",
+    ),
+    "POL": (
+        "ATO Workbook (TRANSPORT POLICY (POL)).xlsx",
+        "sha256:fbf23b012590b631239654d255d23ccb70fa717b466be8343a5b0f1e8b4ce720",
+    ),
+    "RSA": (
+        "ATO Workbook (ROAD SAFETY (RSA)).xlsx",
+        "sha256:eda9e8700e5f22b02b50d37dddbc7e082706252f4e9f215a610268d8e94e8669",
+    ),
+    "SEC": (
+        "ATO Workbook (SOCIO-ECONOMIC (SEC)).xlsx",
+        "sha256:a7a527355a3c90b66455ea126cfd10e99f818a161d20c115a45c0ed0d379c13a",
+    ),
+    "TAS": (
+        "ATO Workbook (TRANSPORT ACTIVITY & SERVICES (TAS)).xlsx",
+        "sha256:b6dd6e5feeb7a54d009ba752acbf8007613a52610b6daeb1170214d69f9a3444",
+    ),
 }
 
 VERSION = "0.1.0"
 
 
 def expand(fname: str) -> str:
-    return FILES.get(fname, fname)
+    return FILES.get(fname, (fname, None))[0]
 
 
 def _make_url(fname: str) -> str:
@@ -61,7 +88,7 @@ def _make_url(fname: str) -> str:
 POOCH = Pooch(
     module=__name__,
     base_url=BASE_URL,
-    registry={expand(key): None for key in FILES.keys()},
+    registry={v[0]: v[1] for v in FILES.values()},
     urls={expand(key): _make_url(key) for key in FILES.keys()},
     expand=expand,
 )

--- a/transport_data/adb/__init__.py
+++ b/transport_data/adb/__init__.py
@@ -38,23 +38,23 @@ FILES = {
     # "ATO National Database Masterlist of Indicators",
     "ACC": (
         "ATO Workbook (ACCESS & CONNECTIVITY (ACC)).xlsx",
-        "sha256:edd027a7f74bbdf82145f17acd6ecd8bd1fdd92d2e5e2be4bbcaaff09879e3de",
+        "sha256:21c3b7e662d932f5cc61c22489acb3cf0e8a70200abc2372c7fe212602903fd7",
     ),
     "APH": (
         "ATO Workbook (AIR POLLUTION & HEALTH (APH)).xlsx",
-        "sha256:548cfcf1f376dad747a3f1cebf7139767ba5bae5ee66aabd598f40a9e9890d20",
+        "sha256:b06c102a1184ed83d77673146599e11c2b6c81d784ebcee6b46f4d43713e899a",
     ),
     "CLC": (
         "ATO Workbook (CLIMATE CHANGE (CLC)).xlsx",
-        "sha256:aba2f02d684fe83c781378ae62ce4b1d548dd6737fe29768c86c620ed8efd65d",
+        "sha256:7fe2d4bb656508bf3194406d25ed04c1ac403daaaf1ada74847a2c330efcfb2a",
     ),
     "INF": (
         "ATO Workbook (INFRASTRUCTURE (INF)).xlsx",
-        "sha256:ea36a9303286b3d1ff5848b01402f8661d968771aa8b980db0aea73a00a9d0dd",
+        "sha256:30b9d05330838809ff0d53b2e61ade935eccdb4b73c0509fd1fc49b405699ac3",
     ),
     "MIS": (
         "ATO Workbook (MISCELLANEOUS (MIS)).xlsx",
-        "sha256:f17315b40434009966580bc3023c222d254b87a1b0c5eaf05a6a42c113b5393b",
+        "sha256:2ef3cdc5e6363cdca1f671bbf12bf0463fe8a4210cb49b3d32ebd2440c6fe6df",
     ),
     "POL": (
         "ATO Workbook (TRANSPORT POLICY (POL)).xlsx",
@@ -62,15 +62,15 @@ FILES = {
     ),
     "RSA": (
         "ATO Workbook (ROAD SAFETY (RSA)).xlsx",
-        "sha256:eda9e8700e5f22b02b50d37dddbc7e082706252f4e9f215a610268d8e94e8669",
+        "sha256:a4285d129c2739c8660a07a5d1c9902ec21c3cd4d13a2a9dfe9d49daca2c0dd5",
     ),
     "SEC": (
         "ATO Workbook (SOCIO-ECONOMIC (SEC)).xlsx",
-        "sha256:a7a527355a3c90b66455ea126cfd10e99f818a161d20c115a45c0ed0d379c13a",
+        "sha256:b5d2ee5d07b5554ef262436ef898afd976fbb4956bd7cb850829cb7391d207c0",
     ),
     "TAS": (
         "ATO Workbook (TRANSPORT ACTIVITY & SERVICES (TAS)).xlsx",
-        "sha256:b6dd6e5feeb7a54d009ba752acbf8007613a52610b6daeb1170214d69f9a3444",
+        "sha256:628d4e9774f84d30d80706e982e4ddf7187d77f8676e69765c307701da1caf77",
     ),
 }
 

--- a/transport_data/data/tests/ckan/package.json
+++ b/transport_data/data/tests/ckan/package.json
@@ -1,0 +1,116 @@
+{
+  "author": null,
+  "author_email": null,
+  "contributors": [],
+  "creator_user_id": "50bb4200-615b-4921-a8da-58f9d53ad9d0",
+  "data_access": "publicly available",
+  "data_provider": "OICA",
+  "dimensioning": "vehicle production by country/region and type (passenger cars, LDV, heavy trucks, buses & coaches)",
+  "frequency": "as_needed",
+  "geographies": [],
+  "groups": [
+    {
+      "description": "",
+      "display_name": "Worldwide",
+      "id": "85cb14f3-72ca-47a7-b8f0-ad5fc78de45a",
+      "image_display_url": "",
+      "name": "worldwide",
+      "title": "Worldwide"
+    }
+  ],
+  "id": "8decd067-a38a-4834-a70c-40419b17fe9c",
+  "indicators": [
+    "Vehicle production"
+  ],
+  "is_archived": false,
+  "isopen": true,
+  "language": "en",
+  "license_id": "CC-BY-4.0",
+  "license_title": "Creative Commons Attribution 4.0",
+  "license_url": "https://creativecommons.org/licenses/by/4.0/",
+  "maintainer": null,
+  "maintainer_email": null,
+  "metadata_created": "2024-10-29T12:25:58.933848",
+  "metadata_modified": "2024-10-29T12:26:02.452514",
+  "modes": [
+    "cars",
+    "private-cars",
+    "truck",
+    "bus"
+  ],
+  "name": "2023-production-statistics",
+  "notes": "This OICA statistics web page contains world motor vehicle production statistics, obtained from national trade organizations, OICA members or correspondents.",
+  "num_resources": 1,
+  "num_tags": 0,
+  "organization": {
+    "approval_status": "approved",
+    "created": "2024-10-29T12:13:41.185874",
+    "description": "",
+    "id": "5eb6e69f-0b49-4c16-8cfa-3fdbba4492e7",
+    "image_url": "",
+    "is_organization": true,
+    "name": "oica",
+    "state": "active",
+    "title": "OICA",
+    "type": "organization"
+  },
+  "owner_org": "5eb6e69f-0b49-4c16-8cfa-3fdbba4492e7",
+  "private": false,
+  "regions": [
+    "worldwide"
+  ],
+  "relationships_as_object": [],
+  "relationships_as_subject": [],
+  "resources": [
+    {
+      "cache_last_updated": null,
+      "cache_url": null,
+      "created": "2024-10-29T12:26:02.463411",
+      "datastore_active": false,
+      "description": null,
+      "format": "",
+      "hash": "",
+      "id": "e28f2207-e153-451e-a9e2-234473c50897",
+      "last_modified": null,
+      "metadata_modified": "2024-10-29T12:26:02.458704",
+      "mimetype": null,
+      "mimetype_inner": null,
+      "name": "Passenger-Cars-2023",
+      "package_id": "8decd067-a38a-4834-a70c-40419b17fe9c",
+      "position": 0,
+      "resource_type": "data",
+      "size": null,
+      "state": "active",
+      "url": "https://www.oica.net/wp-content/uploads/Passenger-Cars-2023.xlsx",
+      "url_type": null
+    }
+  ],
+  "sectors": [
+    "road"
+  ],
+  "services": [
+    "passenger"
+  ],
+  "sources": [
+    {
+      "title": "Cooperation with Ward Auto (America)",
+      "url": "https://www.wardsauto.com/"
+    },
+    {
+      "title": "Asian Automotive Analysis Fourin (Asia)",
+      "url": "https://aaa.fourin.com/"
+    }
+  ],
+  "state": "active",
+  "tags": [],
+  "tdc_category": "public",
+  "temporal_coverage_end": "2023-01-01",
+  "temporal_coverage_start": "1999-01-01",
+  "title": "2023 production statistics",
+  "type": "dataset",
+  "units": [
+    "#"
+  ],
+  "url": "https://www.oica.net/production-statistics/",
+  "version": null
+}

--- a/transport_data/oica/__init__.py
+++ b/transport_data/oica/__init__.py
@@ -140,7 +140,7 @@ def convert_single_file(
         pattern = r"(PC|CV|TOTAL) WORLD VEHICLES IN USE +\(in thousand units\)"
         units = "kvehicle"
 
-    if match := re.fullmatch(pattern, df.iloc[0, 0]):
+    if match := re.fullmatch(pattern, str(df.iloc[0, 0])):
         # Codes are inconsistent across files; use shorter codes
         vehicle_type = {
             "ALL TYPES": "_T",
@@ -192,7 +192,7 @@ def convert_single_file(
     for m, group_df in df.groupby("MEASURE"):
         # Create structures for this measure
         # TODO Retrieve possibly-cached or -stored structures
-        dfd, dsd = get_structures(m)
+        dfd, dsd = get_structures(str(m))
 
         # Create a data set
         ds = DataSet(described_by=dfd, structured_by=dsd)

--- a/transport_data/org/ckan.py
+++ b/transport_data/org/ckan.py
@@ -1,3 +1,5 @@
+""":class:`.ckan.Client` objects to access TDC instances."""
+
 from transport_data.util.ckan import Client
 
 #: Development instance of TDC CKAN. Accessible as of 2024-11-27.

--- a/transport_data/org/ckan.py
+++ b/transport_data/org/ckan.py
@@ -1,0 +1,10 @@
+from transport_data.util.ckan import Client
+
+#: Development instance of TDC CKAN. Accessible as of 2024-11-27.
+DEV = Client("https://ckan.tdc.dev.datopian.com")
+
+#: Production instance of TDC CKAN. Accessible as of 2024-11-27.
+PROD = Client("https://ckan.transport-data.org")
+
+#: Staging instance of TDC CKAN. Not accessible as of 2024-11-27; SSL certificate error.
+STAGING = Client("https://ckan.tdc.staging.datopian.com")

--- a/transport_data/org/metadata/spreadsheet.py
+++ b/transport_data/org/metadata/spreadsheet.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 from sdmx.model import common, v21
 
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     import pathlib
 
     from openpyxl import Workbook
+    from openpyxl.cell.cell import Cell
     from openpyxl.worksheet.worksheet import Worksheet
 
     from transport_data.util.sdmx import MAKeywords
@@ -57,7 +58,7 @@ To add information about additional data flows not included in existing sheets
 def _header(ws: "Worksheet", *columns: Tuple[str, int]) -> None:
     """Write header columns and format their style and width."""
     for column, (value, width) in enumerate(columns, start=1):
-        cell = ws.cell(row=1, column=column, value=value)
+        cell = cast("Cell", ws.cell(row=1, column=column, value=value))
         cell.style = "header"
         ws.column_dimensions[cell.column_letter].width = width
 

--- a/transport_data/tests/org/test_ckan.py
+++ b/transport_data/tests/org/test_ckan.py
@@ -23,4 +23,4 @@ def test_main(instance, N_exp: int) -> None:
 
     assert p is result[0]  # Same object instance returned
 
-    assert "dataset" == p.data["type"]
+    assert "dataset" == p.type

--- a/transport_data/tests/org/test_ckan.py
+++ b/transport_data/tests/org/test_ckan.py
@@ -1,0 +1,26 @@
+import pytest
+from requests.exceptions import SSLError
+
+from transport_data.org.ckan import DEV, PROD, STAGING
+
+
+@pytest.mark.parametrize(
+    "instance, N_exp",
+    [
+        # (DEV, 451),
+        (DEV, 5),
+        # (PROD, 418),
+        (PROD, 5),
+        pytest.param(STAGING, None, marks=pytest.mark.xfail(raises=SSLError)),
+    ],
+)
+def test_main(instance, N_exp: int) -> None:
+    result = instance.package_list(max=5)
+
+    assert N_exp <= len(result)
+
+    p = instance.package_show(result[0])
+
+    assert p is result[0]  # Same object instance returned
+
+    assert "dataset" == p.data["type"]

--- a/transport_data/tests/util/test_ckan.py
+++ b/transport_data/tests/util/test_ckan.py
@@ -1,8 +1,19 @@
 import pytest
-from ckanapi.errors import CKANAPIError, NotAuthorized, ValidationError
+from ckanapi.errors import (
+    CKANAPIError,
+    # NotAuthorized,
+    ValidationError,
+)
 from pytest import param
 
-from transport_data.util.ckan import Client
+from transport_data.util.ckan import (
+    Client,
+    Group,
+    Organization,
+    Package,
+    Resource,
+    get_class,
+)
 
 _500 = pytest.mark.xfail(raises=CKANAPIError, reason="500 Internal Server Error")
 _Incomplete = pytest.mark.xfail(
@@ -11,13 +22,49 @@ _Incomplete = pytest.mark.xfail(
 _NotImplemented = pytest.mark.xfail(
     raises=CKANAPIError, reason="Not implemented by .org.ckan.DEV"
 )
-_NotAuthorized = pytest.mark.xfail(raises=NotAuthorized, reason="Needs API key")
+# _NotAuthorized = pytest.mark.xfail(raises=NotAuthorized, reason="Needs API key")
+_NotAuthorized = pytest.mark.skip(reason="Needs API key")
+
+
+class TestPackage:
+    """These also function as tests of :class:`.ModelProxy`."""
+
+    @pytest.fixture
+    def obj(self, test_data_path) -> Package:
+        """:class:`.Package` instance from a test specimen file."""
+        return Package.from_file(test_data_path.joinpath("ckan", "package.json"))
+
+    def test_asdict(self, obj) -> None:
+        obj.asdict()
+
+    def test_get_item(self, obj) -> None:
+        g = obj.get_item("groups", 0)
+        assert isinstance(g, Group)
+
+        r = obj.get_item("resources", 0)
+        assert isinstance(r, Resource)
+
+    def test_init_name_only(self) -> None:
+        p = Package(name="foo-bar")
+        assert "<CKAN Package 'foo-bar' with 0 fields>" == repr(p)
+
+    def test_len(self, obj) -> None:
+        assert 47 == len(obj)
+
+    def test_update(self, obj) -> None:
+        with pytest.raises(ValueError):
+            obj.update({"id": "foo"})
+        with pytest.raises(ValueError):
+            obj.update({"name": "foo"})
+
+    def test_repr(self, obj) -> None:
+        assert "46 fields" in repr(obj)
 
 
 class TestClient:
     @pytest.fixture
     def c(self) -> "Client":
-        # FIXME Use the TestCKAN provided by the ckanapi package
+        # FIXME Use a mock API
         from transport_data.org.ckan import DEV
 
         return DEV
@@ -30,82 +77,105 @@ class TestClient:
     def test_package_show(self, c) -> None:
         packages = c.package_list(limit=1, max=1)
         p = c.package_show(packages[0])
+        assert isinstance(p, Package)
         assert p.id is not None
 
-    def test_tag_list(self, c) -> None:
-        result = c.tag_list()
-        assert 1 <= len(result)
-
-    # Tests of other HTTP GET API endpoints via call_action
+    # Generic tests of other HTTP GET API endpoints via call_action
     @pytest.mark.parametrize(
-        "action",
+        "action, args",
         [
-            param("am_following_dataset", marks=_Incomplete),
-            param("am_following_group", marks=_Incomplete),
-            param("am_following_organization", marks=_NotImplemented),
-            param("am_following_user", marks=_Incomplete),
-            param("api_token_list", marks=_Incomplete),
-            param("config_option_list", marks=_NotAuthorized),
-            param("config_option_show", marks=_NotAuthorized),
-            "current_package_list_with_resources",
-            param("dataset_followee_count", marks=_Incomplete),
-            param("dataset_followee_list", marks=_NotAuthorized),
-            param("dataset_follower_count", marks=_Incomplete),
-            param("dataset_follower_list", marks=_NotAuthorized),
-            param("followee_count", marks=_Incomplete),
-            param("followee_list", marks=_Incomplete),
-            param("format_autocomplete", marks=_Incomplete),
-            param("get_site_user", marks=_NotAuthorized),
-            param("group_autocomplete", marks=_NotImplemented),
-            param("group_followee_count", marks=_Incomplete),
-            param("group_followee_list", marks=_NotAuthorized),
-            param("group_follower_count", marks=_Incomplete),
-            param("group_follower_list", marks=_NotAuthorized),
-            "group_list_authz",
-            "group_list",
-            param("group_package_show", marks=_Incomplete),
-            param("group_show", marks=_Incomplete),
-            param("help_show", marks=_Incomplete),
-            param("job_list", marks=_NotAuthorized),
-            param("job_show", marks=_NotAuthorized),
-            "license_list",
-            param("member_list", marks=_Incomplete),
-            "member_roles_list",
-            param("organization_autocomplete", marks=_500),
-            param("organization_followee_count", marks=_Incomplete),
-            param("organization_followee_list", marks=_NotAuthorized),
-            param("organization_follower_count", marks=_Incomplete),
-            param("organization_follower_list", marks=_NotAuthorized),
-            "organization_list_for_user",
-            "organization_list",
-            param("organization_show", marks=_Incomplete),
-            param("package_autocomplete", marks=_Incomplete),
-            param("package_collaborator_list_for_user", marks=_Incomplete),
-            param("package_collaborator_list", marks=_Incomplete),
-            param("package_relationships_list", marks=_Incomplete),
-            "package_search",
-            param("recently_changed_packages_activity_list", marks=_NotImplemented),
-            param("resource_search", marks=_Incomplete),
-            param("resource_show", marks=_Incomplete),
-            param("resource_view_list", marks=_Incomplete),
-            param("resource_view_show", marks=_Incomplete),
-            "status_show",
-            "tag_autocomplete",
-            "tag_search",
-            param("tag_show", marks=_Incomplete),
-            param("task_status_show", marks=_Incomplete),
-            param("term_translation_show", marks=_Incomplete),
-            param("user_autocomplete", marks=_Incomplete),
-            param("user_followee_count", marks=_Incomplete),
-            param("user_followee_list", marks=_NotAuthorized),
-            param("user_follower_count", marks=_Incomplete),
-            param("user_follower_list", marks=_NotAuthorized),
-            param("user_list", marks=_NotAuthorized),
-            param("user_show", marks=_NotAuthorized),
-            "vocabulary_list",
-            param("vocabulary_show", marks=_Incomplete),
+            param("am_following_dataset", {}, marks=_Incomplete),
+            param("am_following_group", {}, marks=_Incomplete),
+            param("am_following_organization", {}, marks=_NotImplemented),
+            param("am_following_user", {}, marks=_Incomplete),
+            param("api_token_list", {}, marks=_Incomplete),
+            param("config_option_list", {}, marks=_NotAuthorized),
+            param("config_option_show", {}, marks=_NotAuthorized),
+            ("current_package_list_with_resources", {}),
+            param("dataset_followee_count", {}, marks=_Incomplete),
+            param("dataset_followee_list", {}, marks=_NotAuthorized),
+            param("dataset_follower_count", {}, marks=_Incomplete),
+            param("dataset_follower_list", {}, marks=_NotAuthorized),
+            param("followee_count", {}, marks=_Incomplete),
+            param("followee_list", {}, marks=_Incomplete),
+            param("format_autocomplete", {}, marks=_Incomplete),
+            param("get_site_user", {}, marks=_NotAuthorized),
+            param("group_autocomplete", {}, marks=_NotImplemented),
+            param("group_followee_count", {}, marks=_Incomplete),
+            param("group_followee_list", {}, marks=_NotAuthorized),
+            param("group_follower_count", {}, marks=_Incomplete),
+            param("group_follower_list", {}, marks=_NotAuthorized),
+            ("group_list_authz", {}),
+            ("group_list", {}),
+            param("group_package_show", {}, marks=_Incomplete),
+            param("group_show", {}, marks=_Incomplete),
+            param("help_show", {}, marks=_Incomplete),
+            param("job_list", {}, marks=_NotAuthorized),
+            param("job_show", {}, marks=_NotAuthorized),
+            ("license_list", {}),
+            param("member_list", {}, marks=_Incomplete),
+            ("member_roles_list", {}),
+            param("organization_autocomplete", {}, marks=_500),
+            param("organization_followee_count", {}, marks=_Incomplete),
+            param("organization_followee_list", {}, marks=_NotAuthorized),
+            param("organization_follower_count", {}, marks=_Incomplete),
+            param("organization_follower_list", {}, marks=_NotAuthorized),
+            ("organization_list_for_user", {}),
+            ("organization_list", {}),
+            ("organization_show", {"name": "transport-data-commons"}),
+            param("package_autocomplete", {}, marks=_Incomplete),
+            param("package_collaborator_list_for_user", {}, marks=_Incomplete),
+            param("package_collaborator_list", {}, marks=_Incomplete),
+            param("package_relationships_list", {}, marks=_Incomplete),
+            ("package_search", {}),
+            ("package_show", {"id": "8decd067-a38a-4834-a70c-40419b17fe9c"}),
+            ("package_show", {"name": "2023-production-statistics"}),
+            param("recently_changed_packages_activity_list", {}, marks=_NotImplemented),
+            param("resource_search", {}, marks=_Incomplete),
+            param("resource_show", {}, marks=_Incomplete),
+            param("resource_view_list", {}, marks=_Incomplete),
+            param("resource_view_show", {}, marks=_Incomplete),
+            ("status_show", {}),
+            ("tag_autocomplete", {}),
+            ("tag_list", {}),
+            ("tag_search", {}),
+            ("tag_show", {"name": "transport"}),
+            param("task_status_show", {}, marks=_Incomplete),
+            param("term_translation_show", {}, marks=_Incomplete),
+            param("user_autocomplete", {}, marks=_Incomplete),
+            param("user_followee_count", {}, marks=_Incomplete),
+            param("user_followee_list", {}, marks=_NotAuthorized),
+            param("user_follower_count", {}, marks=_Incomplete),
+            param("user_follower_list", {}, marks=_NotAuthorized),
+            param("user_list", {}, marks=_NotAuthorized),
+            param("user_show", {}, marks=_NotAuthorized),
+            ("vocabulary_list", {}),
+            param("vocabulary_show", {}, marks=_Incomplete),
         ],
     )
-    def test_call_action_getattr(self, c, action) -> None:
-        result = getattr(c, action)()
+    def test_call_action_getattr(self, c, action, args) -> None:
+        """Test calling actions accessed as class attributes."""
+        method = getattr(c, action)
+
+        result = method(args) if args else method()
+
         del result
+
+    @pytest.mark.parametrize(
+        "arg",
+        (
+            "transport-data-commons",
+            "94861715-012e-4467-8353-ab6d1a9c32f9",
+            {"name": "transport-data-commons"},
+            {"id": "94861715-012e-4467-8353-ab6d1a9c32f9"},
+            Organization(name="transport-data-commons"),
+            Organization(id="94861715-012e-4467-8353-ab6d1a9c32f9"),
+        ),
+    )
+    def test_show_action(self, c, arg) -> None:
+        result = c.show_action(arg, _cls=Organization)
+        del result
+
+
+def test_get_class() -> None:
+    assert None is get_class("foo")

--- a/transport_data/tests/util/test_ckan.py
+++ b/transport_data/tests/util/test_ckan.py
@@ -1,0 +1,111 @@
+import pytest
+from ckanapi.errors import CKANAPIError, NotAuthorized, ValidationError
+from pytest import param
+
+from transport_data.util.ckan import Client
+
+_500 = pytest.mark.xfail(raises=CKANAPIError, reason="500 Internal Server Error")
+_Incomplete = pytest.mark.xfail(
+    raises=ValidationError, reason="Incomplete test; needs args"
+)
+_NotImplemented = pytest.mark.xfail(
+    raises=CKANAPIError, reason="Not implemented by .org.ckan.DEV"
+)
+_NotAuthorized = pytest.mark.xfail(raises=NotAuthorized, reason="Needs API key")
+
+
+class TestClient:
+    @pytest.fixture
+    def c(self) -> "Client":
+        # FIXME Use the TestCKAN provided by the ckanapi package
+        from transport_data.org.ckan import DEV
+
+        return DEV
+
+    # Tests of explicit methods
+    def test_package_list(self, c) -> None:
+        result = c.package_list()
+        assert 1 <= len(result)
+
+    def test_package_show(self, c) -> None:
+        packages = c.package_list(limit=1, max=1)
+        p = c.package_show(packages[0])
+        assert p.id is not None
+
+    def test_tag_list(self, c) -> None:
+        result = c.tag_list()
+        assert 1 <= len(result)
+
+    # Tests of other HTTP GET API endpoints via call_action
+    @pytest.mark.parametrize(
+        "action",
+        [
+            param("am_following_dataset", marks=_Incomplete),
+            param("am_following_group", marks=_Incomplete),
+            param("am_following_organization", marks=_NotImplemented),
+            param("am_following_user", marks=_Incomplete),
+            param("api_token_list", marks=_Incomplete),
+            param("config_option_list", marks=_NotAuthorized),
+            param("config_option_show", marks=_NotAuthorized),
+            "current_package_list_with_resources",
+            param("dataset_followee_count", marks=_Incomplete),
+            param("dataset_followee_list", marks=_NotAuthorized),
+            param("dataset_follower_count", marks=_Incomplete),
+            param("dataset_follower_list", marks=_NotAuthorized),
+            param("followee_count", marks=_Incomplete),
+            param("followee_list", marks=_Incomplete),
+            param("format_autocomplete", marks=_Incomplete),
+            param("get_site_user", marks=_NotAuthorized),
+            param("group_autocomplete", marks=_NotImplemented),
+            param("group_followee_count", marks=_Incomplete),
+            param("group_followee_list", marks=_NotAuthorized),
+            param("group_follower_count", marks=_Incomplete),
+            param("group_follower_list", marks=_NotAuthorized),
+            "group_list_authz",
+            "group_list",
+            param("group_package_show", marks=_Incomplete),
+            param("group_show", marks=_Incomplete),
+            param("help_show", marks=_Incomplete),
+            param("job_list", marks=_NotAuthorized),
+            param("job_show", marks=_NotAuthorized),
+            "license_list",
+            param("member_list", marks=_Incomplete),
+            "member_roles_list",
+            param("organization_autocomplete", marks=_500),
+            param("organization_followee_count", marks=_Incomplete),
+            param("organization_followee_list", marks=_NotAuthorized),
+            param("organization_follower_count", marks=_Incomplete),
+            param("organization_follower_list", marks=_NotAuthorized),
+            "organization_list_for_user",
+            "organization_list",
+            param("organization_show", marks=_Incomplete),
+            param("package_autocomplete", marks=_Incomplete),
+            param("package_collaborator_list_for_user", marks=_Incomplete),
+            param("package_collaborator_list", marks=_Incomplete),
+            param("package_relationships_list", marks=_Incomplete),
+            "package_search",
+            param("recently_changed_packages_activity_list", marks=_NotImplemented),
+            param("resource_search", marks=_Incomplete),
+            param("resource_show", marks=_Incomplete),
+            param("resource_view_list", marks=_Incomplete),
+            param("resource_view_show", marks=_Incomplete),
+            "status_show",
+            "tag_autocomplete",
+            "tag_search",
+            param("tag_show", marks=_Incomplete),
+            param("task_status_show", marks=_Incomplete),
+            param("term_translation_show", marks=_Incomplete),
+            param("user_autocomplete", marks=_Incomplete),
+            param("user_followee_count", marks=_Incomplete),
+            param("user_followee_list", marks=_NotAuthorized),
+            param("user_follower_count", marks=_Incomplete),
+            param("user_follower_list", marks=_NotAuthorized),
+            param("user_list", marks=_NotAuthorized),
+            param("user_show", marks=_NotAuthorized),
+            "vocabulary_list",
+            param("vocabulary_show", marks=_Incomplete),
+        ],
+    )
+    def test_call_action_getattr(self, c, action) -> None:
+        result = getattr(c, action)()
+        del result

--- a/transport_data/util/ckan.py
+++ b/transport_data/util/ckan.py
@@ -1,12 +1,28 @@
-from dataclasses import dataclass, field
+"""Utilities for interacting with CKAN instances via their Action API.
+
+The :mod:`ckanapi` package (`PyPI <https://pypi.org/project/ckanapi/>`_,
+`GitHub <https://github.com/ckan/ckanapi>`_), maintained by the CKAN organization,
+provides Pythonic access to the “CKAN Action API” (
+`documentation <https://docs.ckan.org/en/latest/api/index.html>`_), which itself exposes
+nearly all of the functionality available through the CKAN web interface and the TDC
+front-end.
+
+The :class:`~.ckan.Client` class is a wrapper around the :class:`ckanapi.RemoteCKAN`
+class that provides conveniences used by other code in :mod:`transport_data`.
+"""
+
+from functools import partialmethod
 from importlib.metadata import version
 from itertools import count
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, TypeVar, Union
 from warnings import filterwarnings
 
 if TYPE_CHECKING:
+    import pathlib
+
     from ckanapi import RemoteCKAN
 
+# Work around https://github.com/ckan/ckanapi/pull/218 in ckanapi <= 4.8
 filterwarnings(
     "ignore", "pkg_resources is deprecated", DeprecationWarning, "ckanapi.version"
 )
@@ -14,39 +30,124 @@ filterwarnings(
     "ignore", ".*pkg_resources.declare_namespace", DeprecationWarning, "pkg_resources"
 )
 
+T = TypeVar("T", bound="ModelProxy")
 
-@dataclass
-class Package:
-    """Simple proxy for the JSON :attr:`data` about a CKAN 'package'.
 
-    This mirrors, in a much reduced form, `ckan.model.Package
-    <https://github.com/ckan/ckan/blob/master/ckan/model/package.py>`_. A separate class
-    is used to avoid a dependency on CKAN itself and its heavier dependencies.
+class ModelProxy:
+    """Simple proxy for a CKAN object/model.
+
+    :mod:`ckan` itself is a Python package, but is fairly ‘heavy’—a large package with
+    many dependencies. ModelProxy allows to interact with the different classes of
+    CKAN objects based on the JSON data returned by the CKAN Action API, without a
+    dependency on :class:`ckan` itself.
     """
 
-    name: str
+    name: Optional[str] = None
     id: Optional[str] = None
 
-    data: dict = field(default_factory=dict)
+    _collections: dict[str, str] = dict()
+
+    def __init__(self, data: Optional[dict] = None, **kwargs) -> None:
+        self.__dict__.update(data or {})
+        self.__dict__.update(kwargs)
+
+    def __len__(self) -> int:
+        return len(self.__dict__)
+
+    def __repr__(self) -> str:
+        return (
+            f"<CKAN {type(self).__name__} "
+            + (repr(self.name) if self.name else "(no name)")
+            + f" with {len(self.__dict__) - 1} fields>"
+        )
+
+    @classmethod
+    def from_file(cls: type[T], path: "pathlib.Path") -> T:
+        """Construct a new instance from a file `path`."""
+        import json
+
+        with open(path) as f:
+            return cls(json.load(f))
+
+    def asdict(self) -> dict:
+        """Return the original dictionary of object data."""
+        return self.__dict__.copy()
+
+    def get_item(self, name: str, index: Optional[int] = None):
+        """Get a member of a collection."""
+        data = self.__dict__[name][index]
+        cls = get_class(name)
+        assert cls
+        return cls(data)
 
     def update(self, data: dict) -> None:
-        # Update the full data
-        self.data = data
+        """Update part or all of the object data."""
+        # Check some items
+        if self.name and data.get("name", self.name) != self.name:
+            raise ValueError(f"Cannot update with {data['name']!r} != {self.name=!r}")
+        elif self.id and data.get("id", self.id) != self.id:
+            raise ValueError(f"Cannot update with {data['id']!r} != {self.id=!r}")
+        self.__dict__.update(data)
 
-        # Check and unpack some items
-        assert data["name"] == self.name
 
-        assert (self.id or data["id"]) == data["id"]
-        self.id = data["id"]
+def get_class(name: str) -> Optional[type[ModelProxy]]:
+    """Return a :class:`.ModelProxy` subclass given `name`."""
+    glb = globals()
+    for candidate in (
+        name.title(),
+        name.rstrip("s").title(),
+        {"member_role": "MemberRole"}.get(name.rstrip("s"), ""),
+    ):
+        try:
+            return glb[candidate]
+        except KeyError:
+            pass
+    return None
 
 
-@dataclass
-class Resource:
-    """Simple proxy for the JSON :attr:`data` about a CKAN 'resource'.
+class Group(ModelProxy):
+    """Proxy for `ckan.model.Group
+    <https://github.com/ckan/ckan/blob/master/ckan/model/group.py>`_.
+    """
 
-    This mirrors, in a much reduced form, `ckan.model.Resource
-    <https://github.com/ckan/ckan/blob/master/ckan/model/resource.py>`_. A separate
-    class is used to avoid a dependency on CKAN itself and its heavier dependencies.
+
+class Organization(Group):
+    """'Organization' is a synonym for 'Group'."""
+
+    # NB this is a subclass instead of `Organization = Group` so that type(…).__name__
+    #    gives 'organization'
+
+
+class MemberRole(ModelProxy):
+    """Proxy for the CKAN 'MemberRole' model.
+
+    .. todo:: Add a link to the proxied class.
+    """
+
+
+class License(ModelProxy):
+    """Proxy for `ckan.model.License
+    <https://github.com/ckan/ckan/blob/master/ckan/model/license.py>`_.
+    """
+
+
+class Package(ModelProxy):
+    """Proxy for `ckan.model.Package
+    <https://github.com/ckan/ckan/blob/master/ckan/model/package.py>`_.
+    """
+
+
+class Resource(ModelProxy):
+    """Proxy for `ckan.model.Resource
+    <https://github.com/ckan/ckan/blob/master/ckan/model/resource.py>`_.
+    """
+
+
+class Tag(ModelProxy):
+    """Proxy for the CKAN 'Tag' model.
+
+    The source code for the proxied class is `here
+    <>`_.
     """
 
 
@@ -57,7 +158,10 @@ class Client:
 
     - Iterating over calls with rate limits.
     - Caching results, including combined results from multiple calls.
-    - Converting return values to instances of :class:`Package` and :class:`Resource`.
+    - Converting return values to instances of :class:`ModelProxy` subclasses.
+
+    .. todo::
+       - Handle API keys via :mod:`transport_data.config`.
     """
 
     _api: "RemoteCKAN"
@@ -73,63 +177,98 @@ class Client:
         )
 
         self._api = RemoteCKAN(address, user_agent=user_agent)
-
         self._cache = dict(package=dict())
 
     def __getattr__(self, name: str):
         return getattr(self._api.action, name)
 
-    def package_list(
-        self, limit: Optional[int] = None, max: Optional[int] = None
-    ) -> list[Package]:
-        """Call the 'package_list' API endpoint.
+    def list_action(
+        self, kind: str, limit: Optional[int] = None, max: Optional[int] = None
+    ) -> list:
+        """Call the ``{kind}_list`` API endpoint.
 
         Parameters
         ----------
+        kind
+            String identifying the kind of CKAN object to fetch.
         limit
             Number of results to fetch in a single query.
         max
             Maximum number of results to fetch.
         """
+        cls = get_class(kind)
+        assert cls
+
         limit = limit or 100
-        c = self._cache["package_list"] = list()
+
+        c = self._cache[f"{kind}_list"] = list()
+
         for i in count():
             result = self._api.call_action(
-                "package_list", data_dict={"limit": limit, "offset": i * limit}
+                f"{kind}_list", data_dict={"limit": limit, "offset": i * limit}
             )
             c.extend(result)
             if len(result) < limit or (max and max < (i + 1) * limit):
                 break
-        return [Package(v) for v in c]
+        return [(cls(name=v) if isinstance(v, str) else cls(v)) for v in c]
 
-    def tag_list(self):
-        """Call the 'tag_list' API endpoint."""
-        return self._api.call_action("tag_list")
+    # Use list_action() to invoke certain CKAN API endpoints
+    group_list = partialmethod(list_action, "group")
+    license_list = partialmethod(list_action, "license")
+    member_roles_list = partialmethod(list_action, "member_roles")
+    organization_list = partialmethod(list_action, "organization")
+    package_list = partialmethod(list_action, kind="package")
+    tag_list = partialmethod(list_action, kind="tag")
 
-    def package_show(self, package: Union[str, Package]) -> Package:
-        """Call the 'package_show' API endpoint.
+    def show_action(self, obj_or_id: Union[str, dict, T], _cls: type[T]) -> T:
+        """Call the ``{kind}_show`` API endpoint.
 
-        If `package` is an instance of :class:`.Package`, its :attr:`~Package.name` is
-        used for the query, and it is updated with the return value. If `package` is
-        :class:`str`, a new :class:`.Package` is returned.
+        If `obj_or_id` is an instance of :class:`.ModelProxy`, its
+        :attr:`~ModelProxy.name` or :attr:`~.ModelProxy.id` is used for the query, and
+        the same instance is updated with the response data and returned. If `obj_or_id`
+        is :class:`str` or :class:`dict` a new instance of a :class:`.ModelProxy`
+        subclass is returned.
 
         The return value is cached.
         """
-        data_dict: dict[str, str] = dict()
-        if isinstance(package, str):
-            data_dict.update(id=package)
-            result = Package(package)
+        if isinstance(obj_or_id, dict):
+            kw: dict[str, str] = obj_or_id
+            kw.update(id=kw.pop("name", kw.get("id", "")))
+            result: Optional[T] = _cls()
         else:
-            data_dict.update(id=package.name)
-            result = package
+            kw = dict()
 
-        response = self._api.call_action("package_show", data_dict)
+        if isinstance(obj_or_id, str):
+            # Query using the "id" keyword
+            kw.update(id=obj_or_id)
+            # Create a new result object according to the type of
+            result = None
+        elif isinstance(obj_or_id, _cls):
+            if obj_or_id.id:
+                kw.update(id=obj_or_id.id)
+            elif obj_or_id.name:
+                kw.update(id=obj_or_id.name)
+            result = obj_or_id
+
+        kind = _cls.__name__.lower()
+
+        response = self._api.call_action(f"{kind}_show", kw)
 
         # TODO Handle whatever exception is raised for an invalid `package`
-        result.update(response)
+        if result is None:
+            result = _cls(response)
+        else:
+            result.update(response)
 
         # Update cache by both UUID and name
         self._cache[result.id] = result
-        self._cache["package"][result.name] = result
+        self._cache.setdefault(kind, dict())
+        self._cache[kind][result.name] = result
 
         return result
+
+    # Use show_action() to invoke certain CKAN API endpoints
+    # TODO Extend to cover all "*_show" endpoints.
+    organization_show = partialmethod(show_action, _cls=Organization)
+    package_show = partialmethod(show_action, _cls=Package)
+    tag_show = partialmethod(show_action, _cls=Tag)

--- a/transport_data/util/ckan.py
+++ b/transport_data/util/ckan.py
@@ -1,0 +1,135 @@
+from dataclasses import dataclass, field
+from importlib.metadata import version
+from itertools import count
+from typing import TYPE_CHECKING, Optional, Union
+from warnings import filterwarnings
+
+if TYPE_CHECKING:
+    from ckanapi import RemoteCKAN
+
+filterwarnings(
+    "ignore", "pkg_resources is deprecated", DeprecationWarning, "ckanapi.version"
+)
+filterwarnings(
+    "ignore", ".*pkg_resources.declare_namespace", DeprecationWarning, "pkg_resources"
+)
+
+
+@dataclass
+class Package:
+    """Simple proxy for the JSON :attr:`data` about a CKAN 'package'.
+
+    This mirrors, in a much reduced form, `ckan.model.Package
+    <https://github.com/ckan/ckan/blob/master/ckan/model/package.py>`_. A separate class
+    is used to avoid a dependency on CKAN itself and its heavier dependencies.
+    """
+
+    name: str
+    id: Optional[str] = None
+
+    data: dict = field(default_factory=dict)
+
+    def update(self, data: dict) -> None:
+        # Update the full data
+        self.data = data
+
+        # Check and unpack some items
+        assert data["name"] == self.name
+
+        assert (self.id or data["id"]) == data["id"]
+        self.id = data["id"]
+
+
+@dataclass
+class Resource:
+    """Simple proxy for the JSON :attr:`data` about a CKAN 'resource'.
+
+    This mirrors, in a much reduced form, `ckan.model.Resource
+    <https://github.com/ckan/ckan/blob/master/ckan/model/resource.py>`_. A separate
+    class is used to avoid a dependency on CKAN itself and its heavier dependencies.
+    """
+
+
+class Client:
+    """Wrapper around :class:`ckanapi.RemoteCKAN`.
+
+    This provides features such as:
+
+    - Iterating over calls with rate limits.
+    - Caching results, including combined results from multiple calls.
+    - Converting return values to instances of :class:`Package` and :class:`Resource`.
+    """
+
+    _api: "RemoteCKAN"
+    _cache: dict
+
+    def __init__(self, address: str) -> None:
+        from ckanapi import RemoteCKAN
+
+        # Construct a user-agent string
+        user_agent = (
+            f"transport_data/{version('transport_data')} "
+            "(+https://docs.transport-data.org)"
+        )
+
+        self._api = RemoteCKAN(address, user_agent=user_agent)
+
+        self._cache = dict(package=dict())
+
+    def __getattr__(self, name: str):
+        return getattr(self._api.action, name)
+
+    def package_list(
+        self, limit: Optional[int] = None, max: Optional[int] = None
+    ) -> list[Package]:
+        """Call the 'package_list' API endpoint.
+
+        Parameters
+        ----------
+        limit
+            Number of results to fetch in a single query.
+        max
+            Maximum number of results to fetch.
+        """
+        limit = limit or 100
+        c = self._cache["package_list"] = list()
+        for i in count():
+            result = self._api.call_action(
+                "package_list", data_dict={"limit": limit, "offset": i * limit}
+            )
+            c.extend(result)
+            if len(result) < limit or (max and max < (i + 1) * limit):
+                break
+        return [Package(v) for v in c]
+
+    def tag_list(self):
+        """Call the 'tag_list' API endpoint."""
+        return self._api.call_action("tag_list")
+
+    def package_show(self, package: Union[str, Package]) -> Package:
+        """Call the 'package_show' API endpoint.
+
+        If `package` is an instance of :class:`.Package`, its :attr:`~Package.name` is
+        used for the query, and it is updated with the return value. If `package` is
+        :class:`str`, a new :class:`.Package` is returned.
+
+        The return value is cached.
+        """
+        data_dict: dict[str, str] = dict()
+        if isinstance(package, str):
+            data_dict.update(id=package)
+            result = Package(package)
+        else:
+            data_dict.update(id=package.name)
+            result = package
+
+        response = self._api.call_action("package_show", data_dict)
+
+        # TODO Handle whatever exception is raised for an invalid `package`
+        result.update(response)
+
+        # Update cache by both UUID and name
+        self._cache[result.id] = result
+        self._cache["package"][result.name] = result
+
+        return result


### PR DESCRIPTION
Closes #3

Housekeeping:
- Switch to faster `uv` to install Python packages.
- Bump versions of mypy and ruff used for code quality checking.
- Add hashes for ATO data files.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
