### PR TITLE
Adjust for pandas v3.0.0

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,12 @@
 What's new
 **********
 
-.. Next release
-.. ============
+Next release
+============
+
+- :mod:`transport_data` supports and is tested with
+  `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,
+   released 2026-01-21 (:pull:`59`).
 
 v26.1.13
 ========

--- a/transport_data/jrc/__init__.py
+++ b/transport_data/jrc/__init__.py
@@ -207,7 +207,16 @@ def _match_extract(df: pd.DataFrame, expr) -> pd.DataFrame:
 def _fill_unit_measure(df: pd.DataFrame, measure: str) -> pd.DataFrame:
     """Fill in the UNIT_MEASURE column of `df`."""
     # Identify the MODE, if any
-    mode = df.get("MODE", default=pd.Series([None])).unique().item()  # type: ignore
+    # commented: Regression in pandas 3.0.0
+    # mode = df.get("MODE", default=pd.Series([None])).unique().item()
+    # Work around pandas-dev/pandas#63876
+    if "MODE" in df.columns:
+        modes = df["MODE"].unique()
+        assert 1 == len(modes)
+        mode = modes[0]
+    else:
+        mode = None
+
     return df.assign(
         UNIT_MEASURE=lambda df: df[["U0", "U1"]]
         .fillna(UNIT_MEASURE.get((mode, measure), ""))


### PR DESCRIPTION
[Pandas 3.0.0 was released 2026-01-21](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html), causing failures in the test suite, e.g. [here](https://github.com/transport-data/tools/actions/runs/21236944695/job/61106813270#step:6:3163).

A fix for one failed test is upstream: khaeru/sdmx#268.

The following failure is pandas-dev/pandas#63876:
```
FAILED transport_data/tests/test_jrc.py::test_convert - AttributeError: 'StringArray' object has no attribute 'item'
```
This PR adjusts the code to work around the issue.
If it is resolved upstream in a future pandas version, the workaround may be removed.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A, bug fix only.
- [x] Update doc/whatsnew.rst
