### PR TITLE
Add `tdc org qr` CLI command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     - Sphinx
     - types-docutils
     - types-openpyxl
+    - types-qrcode
     - types-requests
     - types-tqdm
     args: []

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,6 +8,9 @@ Next release
   `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,
    released 2026-01-21 (:pull:`59`).
 - Update for pycountry 26.2.16, released 2026-02-17 (:pull:`61`).
+- :program:`tdc` command-line interface warns but does not error
+  if some modules/commands are not available (:pull:`63`).
+- New CLI command :program:`tdc org qr` (:pull:`63`).
 - New HOWTO :doc:`Get involved <howto/get-involved>` (:pull:`62`).
 
 v26.1.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-docs = ["furo", "Sphinx", "sphinx-autorun"]
+docs = [
+  "furo",
+  "Sphinx",
+  "sphinx-autorun",
+  'keyrings.alt; sys_platform=="linux"',
+]
 google = ["google-api-python-client", "google-auth-httplib2", "google-auth-oauthlib"]
 keyring = ["keyring"]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,9 @@ tests = [
   "pytest-timeout",
   "pytest-xdist",
   "responses",
-  "transport-data[keyring,google]",
+  "transport-data[keyring,google,qr]",
 ]
+qr = ["qrcode[pil]"]
 
 [project.urls]
 Documentation = "https://docs.transport-data.org"

--- a/transport_data/cli/__init__.py
+++ b/transport_data/cli/__init__.py
@@ -35,8 +35,13 @@ MODULES_WITH_CLI = [
 
 # Add commands from each module that defines them
 for name in MODULES_WITH_CLI:
-    module = import_module(f"transport_data.{name}")
-    main.add_command(getattr(module, "main"))
+    try:
+        full_name = f"transport_data.{name}"
+        module = import_module(full_name)
+    except ImportError as e:
+        print(f"{full_name} commands not available: {e.args[0]}")
+    else:
+        main.add_command(getattr(module, "main"))
 
 
 @main.command()

--- a/transport_data/data/image/logo.png
+++ b/transport_data/data/image/logo.png
@@ -1,0 +1,1 @@
+../../../doc/_static/logo.png

--- a/transport_data/org/cli.py
+++ b/transport_data/org/cli.py
@@ -10,8 +10,12 @@ defined in this module.
 """
 
 import pathlib
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from qrcode.image.base import BaseImageWithDrawer
 
 
 @click.group("org")
@@ -151,3 +155,73 @@ def template():
     from .metadata.spreadsheet import make_workbook
 
     make_workbook()
+
+
+@main.command("qr")
+@click.option("--format", type=click.Choice(["png", "svg"]), default="png")
+@click.argument("data")
+def qr(format: str, data: str) -> None:
+    """Generate QR codes.
+
+    DATA should be a complete URL. A unique filename is generated from the URL, like
+    qr-example-com-foo.png. With --format=png, the TDC logo is embedded.
+    """
+    import re
+    from hashlib import blake2s
+    from importlib.resources import files
+    from urllib.parse import urlparse
+
+    import qrcode
+
+    # Parse the data as a URL
+    url = urlparse(data)
+    # Portion of the URL after the domain
+    path_plus = data.partition(url.netloc)[2].lstrip("/")
+    if re.search(r"[/\?=]", path_plus):
+        # Hash of the path and subsequent URL parts, first 4 characters
+        path_plus = blake2s(path_plus.encode()).hexdigest()[:5]
+    # Construct the output filename
+    filename = f"qr-{url.netloc.replace('.', '-')}{'-' if len(path_plus) else ''}{path_plus}.{format}"
+
+    # Path to the TDC logo for embedding
+    logo_path = files("transport_data").joinpath("data", "image", "logo.png")
+
+    # Construct the QR code
+    qr = qrcode.QRCode(error_correction=qrcode.constants.ERROR_CORRECT_H, border=2)
+    # Add the URL as data
+    qr.add_data(data)
+
+    # Convert to an image
+    if format == "png":
+        # PNG image
+        from qrcode.image.styledpil import StyledPilImage
+        from qrcode.image.styles.colormasks import SolidFillColorMask
+        from qrcode.image.styles.moduledrawers.pil import SquareModuleDrawer
+
+        img: "BaseImageWithDrawer" = qr.make_image(
+            image_factory=StyledPilImage,
+            color_mask=SolidFillColorMask(
+                back_color=(0, 96, 100),  # Same as HTML #006064
+                front_color=(255, 255, 255),  # White
+            ),
+            module_drawer=SquareModuleDrawer(),
+            embedded_image_path=logo_path,
+        )
+    elif format == "svg":
+        # SVG image
+        # NB The documentation is not clear, but it appears not possible to set the
+        #    colours or an embedded image if using SVG.
+        from qrcode.image.styles.moduledrawers.svg import SvgPathSquareDrawer
+        from qrcode.image.svg import SvgPathImage
+
+        img = qr.make_image(
+            image_factory=SvgPathImage,
+            background="#006064",  # Appears to have no effect
+            module_drawer=SvgPathSquareDrawer(),
+            # embedded_image_path=logo_path,  # Not supported
+        )
+
+    # Write to file
+    with open(filename, "wb") as f:
+        img.save(f)
+    print(f"Wrote {filename}")

--- a/transport_data/testing/__init__.py
+++ b/transport_data/testing/__init__.py
@@ -155,7 +155,7 @@ def sdmx_structures(tmp_store) -> sdmx.message.StructureMessage:
 
 
 @pytest.fixture
-def tdc_cli():
+def tdc_cli() -> Iterator[CliRunner]:
     """A :class:`.CliRunner` object that invokes the :program:`tdc` CLI."""
     yield CliRunner()
 

--- a/transport_data/tests/org/test_cli.py
+++ b/transport_data/tests/org/test_cli.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from transport_data.testing import CliRunner
+
+
+@pytest.mark.parametrize(
+    "args, exit_code, stem",
+    (
+        (["--format=png", "https://example.com"], 0, "example-com"),
+        (["--format=svg", "https://example.com"], 0, "example-com"),
+        (["--format=foo", "https://example.com"], 2, ""),
+        (["--format=png", "https://example.com/foo"], 0, "example-com-foo"),
+        (["--format=png", "https://example.com/foo?bar=baz"], 0, "example-com-3098d"),
+    ),
+)
+def test_qr(
+    tmp_path: Path, tdc_cli: CliRunner, args: list[str], exit_code: int, stem: str
+) -> None:
+    with tdc_cli.isolated_filesystem(tmp_path):
+        result = tdc_cli.invoke(["org", "qr"] + args)
+
+    assert exit_code == result.exit_code
+
+    if exit_code:
+        return  # No further checks if the invocation is expected to fail
+
+    # Temporary directory created by CliRunner
+    dir = next(tmp_path.iterdir())
+
+    # 1 file(s) created
+    files = list(dir.iterdir())
+    assert 1 == len(files)
+
+    # Name of created file
+    file = files[0]
+    assert f"qr-{stem}" == file.stem
+    assert "." + args[0][-3:] == file.suffix


### PR DESCRIPTION
This command allows to generate images containing QR codes and the TDC logo.

Also:
- Adjust the command-line interface (`tdc`) so that commands unavailable without certain dependencies are simply not shown/available. For example, if `pytest` is not installed, `tdc test` and subcommands are simply not shown.
- Improve the display of the CLI documentation.

### PR checklist
- [x] Checks all ✅
- [x] Update documentation
- [x] Update doc/whatsnew.rst
